### PR TITLE
Config Flag Fix and Version Bump

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,17 +17,17 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 
 For more information on inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input)
 
-- `version`: The KinD version to use (default: `v0.9.0`)
+- `version`: The KinD version to use (default: `v0.10.0`)
 - `config`: The path to the KinD config file
 - `node_image`: The Docker image for the cluster nodes
 - `cluster_name`: The name of the cluster to create (default: `kind`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for KinD
 - `registry`: Configures an insecure registry on `kind-registry:5000` to be used with KinD (default: `true`)
-- `kubectl_version`: The kubectl version to use (default: `v1.18.6`)
-- `knative_serving`: The version of Knative Serving to install on the Kind cluster (not installed by default - example: `v0.19.0`)
-- `knative_kourier`: The version of Knative Net Kourier to install on the Kind cluster (not installed by default - example: `v0.19.0`)
-- `knative_eventing`: The version of Knative Eventing to install on the Kind cluster (not installed by default - example: `v0.19.0`)
+- `kubectl_version`: The kubectl version to use (default: `v1.20.0`)
+- `knative_serving`: The version of Knative Serving to install on the Kind cluster (not installed by default - example: `v0.20.0`)
+- `knative_kourier`: The version of Knative Net Kourier to install on the Kind cluster (not installed by default - example: `v0.20.0`)
+- `knative_eventing`: The version of Knative Eventing to install on the Kind cluster (not installed by default - example: `v0.20.0`)
 
 ### Example Workflow
 
@@ -67,9 +67,9 @@ jobs:
       - name: Kubernetes KinD Cluster
         uses: container-tools/kind-action@v1
         with:
-          knative_serving: v0.19.0
-          knative_kourier: v0.19.0
-          knative_eventing: v0.19.0
+          knative_serving: v0.20.0
+          knative_kourier: v0.20.0
+          knative_eventing: v0.20.0
 ```
 
 This will install Knative Serving, Eventing and a Kourier Ingress on your Kind cluster. To make Knative run on Kind, resource request and limits are removed from the original Knative descriptors.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for KinD
 - `registry`: Configures an insecure registry on `kind-registry:5000` to be used with KinD (default: `true`)
+- `kubectl_version`: The kubectl version to use (default: `v1.18.6`)
 - `knative_serving`: The version of Knative Serving to install on the Kind cluster (not installed by default - example: `v0.19.0`)
 - `knative_kourier`: The version of Knative Net Kourier to install on the Kind cluster (not installed by default - example: `v0.19.0`)
 - `knative_eventing`: The version of Knative Eventing to install on the Kind cluster (not installed by default - example: `v0.19.0`)

--- a/action.yml
+++ b/action.yml
@@ -19,6 +19,8 @@ inputs:
     description: "The log level for KinD"
   registry:
     description: "Configures an insecure registry on kind-registry:5000 to be used with KinD (default: true)"
+  kubectl_version:
+    description: "The version of kubectl to use (default: v1.18.6)"
   knative_serving:
     description: "The version of Knative Serving to install on the Kind cluster (not installed by default - example: v0.19.0)"
   knative_kourier:

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: cloud
 inputs:
   version:
-    description: "The KinD version to use (default: v0.9.0)"
+    description: "The KinD version to use (default: v0.10.0)"
   config:
     description: "The path to the KinD config file"
   node_image:
@@ -20,13 +20,13 @@ inputs:
   registry:
     description: "Configures an insecure registry on kind-registry:5000 to be used with KinD (default: true)"
   kubectl_version:
-    description: "The version of kubectl to use (default: v1.18.6)"
+    description: "The version of kubectl to use (default: v1.20.0)"
   knative_serving:
-    description: "The version of Knative Serving to install on the Kind cluster (not installed by default - example: v0.19.0)"
+    description: "The version of Knative Serving to install on the Kind cluster (not installed by default - example: v0.20.0)"
   knative_kourier:
-    description: "The version of Knative Net Kourier to install on the Kind cluster (not installed by default - example: v0.19.0)"
+    description: "The version of Knative Net Kourier to install on the Kind cluster (not installed by default - example: v0.20.0)"
   knative_eventing:
-    description: "The version of Knative Eventing to install on the Kind cluster (not installed by default - example: v0.19.0)"
+    description: "The version of Knative Eventing to install on the Kind cluster (not installed by default - example: v0.20.0)"
 runs:
   using: "node12"
   main: "main.js"

--- a/kind.sh
+++ b/kind.sh
@@ -16,9 +16,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DEFAULT_KIND_VERSION=v0.9.0
+DEFAULT_KIND_VERSION=v0.10.0
 DEFAULT_CLUSTER_NAME=kind
-DEFAULT_KUBECTL_VERSION=v1.18.6
+DEFAULT_KUBECTL_VERSION=v1.20.0
 
 show_help() {
 cat << EOF

--- a/kind.sh
+++ b/kind.sh
@@ -18,7 +18,7 @@ set -o pipefail
 
 DEFAULT_KIND_VERSION=v0.9.0
 DEFAULT_CLUSTER_NAME=kind
-KUBECTL_VERSION=v1.18.6
+DEFAULT_KUBECTL_VERSION=v1.18.6
 
 show_help() {
 cat << EOF
@@ -26,6 +26,7 @@ Usage: $(basename "$0") <options>
 
     -h, --help                              Display help
     -v, --version                           The kind version to use (default: $DEFAULT_KIND_VERSION)"
+    -k, --kubectl-version                   The kubectl version to use (default: $DEFAULT_KUBECTL_VERSION)"
     -c, --config                            The path to the kind config file"
     -i, --node-image                        The Docker image for the cluster nodes"
     -n, --cluster-name                      The name of the cluster to create (default: $DEFAULT_CLUSTER_NAME)"
@@ -37,6 +38,7 @@ EOF
 
 main() {
     local version="$DEFAULT_KIND_VERSION"
+    local kubectl_version="$DEFAULT_KUBECTL_VERSION"
     local config=
     local node_image=
     local cluster_name="$DEFAULT_CLUSTER_NAME"
@@ -64,6 +66,16 @@ parse_command_line() {
                     shift
                 else
                     echo "ERROR: '-v|--version' cannot be empty." >&2
+                    show_help
+                    exit 1
+                fi
+                ;;
+            -k|--kubectl-version)
+                if [[ -n "${2:-}" ]]; then
+                    kubectl_version="$2"
+                    shift
+                else
+                    echo "ERROR: '-k|--kubectl-version' cannot be empty." >&2
                     show_help
                     exit 1
                 fi
@@ -136,7 +148,7 @@ install_kind() {
 
 install_kubectl() {
     echo 'Installing kubectl...'
-    curl -sSLO "https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl"
+    curl -sSLO "https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl"
     chmod +x kubectl
     sudo mv kubectl /usr/local/bin/kubectl
 }

--- a/main.sh
+++ b/main.sh
@@ -19,42 +19,47 @@ set -o pipefail
 SCRIPT_DIR=$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" || realpath "${BASH_SOURCE[0]}")")
 
 main() {
-    args=()
+    args_kind=()
+    args_knative=()
 
     if [[ -n "${INPUT_VERSION:-}" ]]; then
-        args+=(--version "${INPUT_VERSION}")
+        args_kind+=(--version "${INPUT_VERSION}")
     fi
 
     if [[ -n "${INPUT_CONFIG:-}" ]]; then
-        args+=(--config "${INPUT_CONFIG}")
+        args_kind+=(--config "${INPUT_CONFIG}")
     fi
 
     if [[ -n "${INPUT_NODE_IMAGE:-}" ]]; then
-        args+=(--node-image "${INPUT_NODE_IMAGE}")
+        args_kind+=(--node-image "${INPUT_NODE_IMAGE}")
     fi
 
     if [[ -n "${INPUT_CLUSTER_NAME:-}" ]]; then
-        args+=(--cluster-name "${INPUT_CLUSTER_NAME}")
+        args_kind+=(--cluster-name "${INPUT_CLUSTER_NAME}")
     fi
 
     if [[ -n "${INPUT_WAIT:-}" ]]; then
-        args+=(--wait "${INPUT_WAIT}")
+        args_kind+=(--wait "${INPUT_WAIT}")
     fi
 
     if [[ -n "${INPUT_LOG_LEVEL:-}" ]]; then
-        args+=(--log-level "${INPUT_LOG_LEVEL}")
+        args_kind+=(--log-level "${INPUT_LOG_LEVEL}")
+    fi
+
+    if [[ -n "${INPUT_KUBECTL_VERSION:-}" ]]; then
+        args_kind+=(--kubectl-version "${INPUT_KUBECTL_VERSION}")
     fi
 
     if [[ -n "${INPUT_KNATIVE_SERVING:-}" ]]; then
-        args+=(--knative-serving "${INPUT_KNATIVE_SERVING}")
+        args_knative+=(--knative-serving "${INPUT_KNATIVE_SERVING}")
     fi
 
     if [[ -n "${INPUT_KNATIVE_KOURIER:-}" ]]; then
-        args+=(--knative-kourier "${INPUT_KNATIVE_KOURIER}")
+        args_knative+=(--knative-kourier "${INPUT_KNATIVE_KOURIER}")
     fi
 
     if [[ -n "${INPUT_KNATIVE_EVENTING:-}" ]]; then
-        args+=(--knative-eventing "${INPUT_KNATIVE_EVENTING}")
+        args_knative+=(--knative-eventing "${INPUT_KNATIVE_EVENTING}")
     fi
 
     if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "${INPUT_REGISTRY,,}" = "true" ]]; then
@@ -63,17 +68,17 @@ main() {
         if [[ -n "${INPUT_CONFIG:-}" ]]; then
             echo 'WARNING: when using the "config" option, you need to manually configure the registry in the provided configuration'
         else
-            args+=(--config "/etc/kind-registry/config.yaml")
+            args_kind+=(--config "/etc/kind-registry/config.yaml")
         fi
     fi
 
-    "$SCRIPT_DIR/kind.sh" "${args[@]}"
+    "$SCRIPT_DIR/kind.sh" "${args_kind[@]}"
 
     if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "${INPUT_REGISTRY,,}" = "true" ]]; then
         "$SCRIPT_DIR/registry.sh" "--document" "true" "${args[@]}"
     fi
 
-    "$SCRIPT_DIR/knative.sh" "${args[@]}"
+    "$SCRIPT_DIR/knative.sh" "${args_knative[@]}"
 }
 
 main


### PR DESCRIPTION
Hi,

This PR fixes a small issue where, if --config flag is passed, the action would prematurely exit when parsing flags on a subsequent script which did not include that as a valid flag.  

Also included is the parameterization of the kubectl version installed, and a version bump for the others.

Thanks for having made this action available; it works well.