### PR TITLE
Add support of MacOS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,7 +11,10 @@ on:
 jobs:
 
   test-default:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -30,7 +33,8 @@ jobs:
         version:
         - v0.11.1
         - v0.10.0
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -52,7 +56,8 @@ jobs:
         version:
         - v0.11.1
         - v0.10.0
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -82,7 +87,8 @@ jobs:
       matrix:
         version:
         - v0.11.1
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -128,7 +134,8 @@ jobs:
         knative_version:
         - v0.24.0
         - v1.0.0
-    runs-on: ubuntu-latest
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/kind.sh
+++ b/kind.sh
@@ -141,16 +141,32 @@ parse_command_line() {
 
 install_kind() {
     echo 'Installing kind...'
-    curl -sSLo kind "https://github.com/kubernetes-sigs/kind/releases/download/$version/kind-linux-amd64"
+    if [ "$RUNNER_OS" == "macOS" ]; then
+        # for Intel Macs
+        [ $(uname -m) = x86_64 ] && curl -sSLo kind "https://kind.sigs.k8s.io/dl/$version/kind-darwin-amd64"
+        # for M1 / ARM Macs
+        [ $(uname -m) = arm64 ] && curl -sSLo kind "https://kind.sigs.k8s.io/dl/$version/kind-darwin-arm64"
+    else
+        curl -sSLo kind "https://github.com/kubernetes-sigs/kind/releases/download/$version/kind-linux-amd64"
+    fi
     chmod +x kind
     sudo mv kind /usr/local/bin/kind
+    kind version
 }
 
 install_kubectl() {
     echo 'Installing kubectl...'
-    curl -sSLO "https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl"
+    if [ "$RUNNER_OS" == "macOS" ]; then
+        # for Intel Macs
+        [ $(uname -m) = x86_64 ] && curl -sSLo kubectl "https://dl.k8s.io/release/$kubectl_version/bin/darwin/amd64/kubectl"
+        # for M1 / ARM Macs
+        [ $(uname -m) = arm64 ] && curl -sSLo kubectl "https://dl.k8s.io/release/$kubectl_version/bin/darwin/arm64/kubectl"
+    else
+        curl -sSLO "https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl"
+    fi
     chmod +x kubectl
     sudo mv kubectl /usr/local/bin/kubectl
+    kubectl version --client --output=yaml
 }
 
 create_kind_cluster() {

--- a/main.sh
+++ b/main.sh
@@ -63,7 +63,12 @@ main() {
     fi
 
     if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "${INPUT_REGISTRY,,}" = "true" ]]; then
-        "$SCRIPT_DIR/registry.sh" "${args[@]}"
+        if [[ ${args:+exist} == "exist" ]] && [[ ${#args[@]} -gt 0 ]]; then
+            "$SCRIPT_DIR/registry.sh" "${args[@]}"
+        else
+            "$SCRIPT_DIR/registry.sh"
+        fi
+        
 
         if [[ -n "${INPUT_CONFIG:-}" ]]; then
             echo 'WARNING: when using the "config" option, you need to manually configure the registry in the provided configuration'
@@ -71,14 +76,24 @@ main() {
             args_kind+=(--config "/etc/kind-registry/config.yaml")
         fi
     fi
-
-    "$SCRIPT_DIR/kind.sh" "${args_kind[@]}"
-
-    if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "${INPUT_REGISTRY,,}" = "true" ]]; then
-        "$SCRIPT_DIR/registry.sh" "--document" "true" "${args[@]}"
+    if [[ ${#args_kind[@]} -gt 0 ]]; then
+        "$SCRIPT_DIR/kind.sh" "${args_kind[@]}"
+    else
+        "$SCRIPT_DIR/kind.sh"
     fi
 
-    "$SCRIPT_DIR/knative.sh" "${args_knative[@]}"
+    if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "${INPUT_REGISTRY,,}" = "true" ]]; then
+        if [[ ${args:+exist} == "exist" ]] && [[ ${#args[@]} -gt 0 ]]; then
+            "$SCRIPT_DIR/registry.sh" "--document" "true" "${args[@]}"
+        else
+            "$SCRIPT_DIR/registry.sh" "--document" "true"
+        fi
+    fi
+    if [[ ${#args_knative[@]} -gt 0 ]]; then
+        "$SCRIPT_DIR/knative.sh" "${args_knative[@]}"
+    else
+        "$SCRIPT_DIR/knative.sh"
+    fi
 }
 
 main

--- a/registry.sh
+++ b/registry.sh
@@ -123,10 +123,14 @@ parse_command_line() {
 
 create_registry() {
     echo "Creating registry \"$registry_name\" on port $registry_port from image \"$registry_image\"..."
+    if [ "$RUNNER_OS" == "macOS" ] && ! [ -x "$(command -v docker)" ]; then
+         brew install docker colima
+         colima start
+    fi
     docker run -d --restart=always -p "${registry_port}:5000" --name "${registry_name}" $registry_image > /dev/null
     
     # Adding registry to /etc/hosts
-    echo "127.0.0.1 $registry_name" | sudo tee --append /etc/hosts
+    sudo -- bash -c 'echo "127.0.0.1 $registry_name" >> /etc/hosts'
 
     # Exporting the registry location for subsequent jobs
     echo "KIND_REGISTRY=${registry_name}:${registry_port}" >> $GITHUB_ENV


### PR DESCRIPTION
## Motivation

To be able to execute tests on GitHub runners that require native compilation, we have to be able to launch them against [a MacOS runner because it has 14 Go of RAM while only 7 Go is available on Linux runners](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources) which is not enough for the new tests that need up to 9.5 Go of RAM.

## Modifications:

* Install docker using `brew` since the version of docker is not part of the input parameters of the action
* Download the binaries of `kubectl` and `kind` corresponding to the local arch
* Check the size of the list before calling them to avoid getting `unbound variable` error
* Avoid using `tee` to append a line to a file since the command is different between MacOS and Linux
* Add `macos-latest` to the OSs to be tested by the CI
* Print the version of `kubectl` and `kind` once installed to ensure that the right version has been installed