### PR TITLE
Upgrade default version of kind and kubectl

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,6 +2,8 @@ name: Test
 
 on:
   pull_request:
+    branches:
+      - main
   push:
     branches:
       - main
@@ -31,8 +33,8 @@ jobs:
     strategy:
       matrix:
         version:
-        - v0.11.1
-        - v0.10.0
+        - v0.17.0
+        - v0.16.0
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -54,8 +56,8 @@ jobs:
     strategy:
       matrix:
         version:
-        - v0.11.1
-        - v0.10.0
+        - v0.17.0
+        - v0.16.0
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -86,7 +88,7 @@ jobs:
     strategy:
       matrix:
         version:
-        - v0.11.1
+        - v0.17.0
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:
@@ -132,8 +134,8 @@ jobs:
     strategy:
       matrix:
         knative_version:
-        - v0.24.0
-        - v1.0.0
+        - v1.9.0
+        - v1.8.1
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,7 +135,6 @@ jobs:
       matrix:
         knative_version:
         - v1.9.0
-        - v1.8.1
         os: [ubuntu-latest, macos-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/README.md
+++ b/README.md
@@ -17,14 +17,14 @@ For more information, reference the GitHub Help Documentation for [Creating a wo
 
 For more information on inputs, see the [API Documentation](https://developer.github.com/v3/repos/releases/#input)
 
-- `version`: The KinD version to use (default: `v0.11.1`)
+- `version`: The KinD version to use (default: `v0.17.0`)
 - `config`: The path to the KinD config file
 - `node_image`: The Docker image for the cluster nodes
 - `cluster_name`: The name of the cluster to create (default: `kind`)
 - `wait`: The duration to wait for the control plane to become ready (default: `60s`)
 - `log_level`: The log level for KinD
 - `registry`: Configures an insecure registry on `kind-registry:5000` to be used with KinD (default: `true`)
-- `kubectl_version`: The kubectl version to use (default: `v1.21.1`)
+- `kubectl_version`: The kubectl version to use (default: `v1.26.1`)
 - `knative_serving`: The version of Knative Serving to install on the Kind cluster (not installed by default - example: `v1.0.0`)
 - `knative_kourier`: The version of Knative Net Kourier to install on the Kind cluster (not installed by default - example: `v1.0.0`)
 - `knative_eventing`: The version of Knative Eventing to install on the Kind cluster (not installed by default - example: `v1.0.0`)

--- a/action.yml
+++ b/action.yml
@@ -6,7 +6,7 @@ branding:
   icon: cloud
 inputs:
   version:
-    description: "The KinD version to use (default: v0.11.1)"
+    description: "The KinD version to use (default: v0.17.0)"
   config:
     description: "The path to the KinD config file"
   node_image:
@@ -20,7 +20,7 @@ inputs:
   registry:
     description: "Configures an insecure registry on kind-registry:5000 to be used with KinD (default: true)"
   kubectl_version:
-    description: "The version of kubectl to use (default: v1.20.0)"
+    description: "The version of kubectl to use (default: v1.26.1)"
   knative_serving:
     description: "The version of Knative Serving to install on the Kind cluster (not installed by default - example: v1.0.0)"
   knative_kourier:

--- a/kind.sh
+++ b/kind.sh
@@ -49,6 +49,7 @@ main() {
 
     install_kind
     install_kubectl
+    install_docker
     create_kind_cluster
 
 }
@@ -167,6 +168,14 @@ install_kubectl() {
     chmod +x kubectl
     sudo mv kubectl /usr/local/bin/kubectl
     kubectl version --client --output=yaml
+}
+
+install_docker() {
+    if [ "$RUNNER_OS" == "macOS" ] && ! [ -x "$(command -v docker)" ]; then
+        echo 'Installing docker...'
+        brew install docker colima
+        colima start
+    fi
 }
 
 create_kind_cluster() {

--- a/kind.sh
+++ b/kind.sh
@@ -16,9 +16,9 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-DEFAULT_KIND_VERSION=v0.11.1
+DEFAULT_KIND_VERSION=v0.17.0
 DEFAULT_CLUSTER_NAME=kind
-DEFAULT_KUBECTL_VERSION=v1.21.1
+DEFAULT_KUBECTL_VERSION=v1.26.1
 
 show_help() {
 cat << EOF

--- a/knative.sh
+++ b/knative.sh
@@ -105,7 +105,9 @@ parse_command_line() {
 
 install_prerequisites() {
     echo "Installing yq for patching Knative resources..."
-    sudo pip install yq
+    wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+    chmod +x /usr/local/bin/yq
+    yq --version
 }
 
 install_serving() {
@@ -118,7 +120,7 @@ install_serving() {
     kubectl apply --filename $base/serving-crds.yaml
     echo "Waiting for resources to be initialized..."
     sleep 5
-    curl -L -s $base/serving-core.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' -y | yq 'del(.metadata.annotations."knative.dev/example-checksum")' -y | kubectl apply -f -
+    curl -L -s $base/serving-core.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' | yq 'del(.metadata.annotations."knative.dev/example-checksum")' | kubectl apply -f -
     echo "Waiting for resources to be initialized..."
     sleep 60
     kubectl get pod -n knative-serving
@@ -151,17 +153,17 @@ install_eventing() {
     kubectl apply --filename $base/eventing-crds.yaml
     echo "Waiting for resources to be initialized..."
     sleep 5
-    curl -L -s $base/eventing-core.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' -y | yq 'del(.metadata.annotations."knative.dev/example-checksum")' -y | kubectl apply -f -
+    curl -L -s $base/eventing-core.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' | yq 'del(.metadata.annotations."knative.dev/example-checksum")' | kubectl apply -f -
     # Eventing channels
     set +e
-    curl -L -s $base/in-memory-channel.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' -y | yq 'del(.metadata.annotations."knative.dev/example-checksum")' -y | kubectl apply -f -
+    curl -L -s $base/in-memory-channel.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' | yq 'del(.metadata.annotations."knative.dev/example-checksum")' | kubectl apply -f -
     if [ $? -ne 0 ]; then
         set -e
         curl -L -s $base/in-memory-channel.yaml | kubectl apply -f -
     fi
     set -e
     # Eventing broker
-    curl -L -s $base/mt-channel-broker.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' -y | yq 'del(.metadata.annotations."knative.dev/example-checksum")' -y | kubectl apply -f -
+    curl -L -s $base/mt-channel-broker.yaml | yq 'del(.spec.template.spec.containers[]?.resources)' | yq 'del(.metadata.annotations."knative.dev/example-checksum")' | kubectl apply -f -
     echo "Waiting for resources to be initialized..."
     sleep 30
     kubectl get pod -n knative-eventing

--- a/knative.sh
+++ b/knative.sh
@@ -105,8 +105,12 @@ parse_command_line() {
 
 install_prerequisites() {
     echo "Installing yq for patching Knative resources..."
-    wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
-    chmod +x /usr/local/bin/yq
+    if [ "$RUNNER_OS" == "macOS" ]; then
+         brew install yq
+    else
+        wget https://github.com/mikefarah/yq/releases/latest/download/yq_linux_amd64 -O /usr/local/bin/yq
+        chmod +x /usr/local/bin/yq
+    fi
     yq --version
 }
 

--- a/main.sh
+++ b/main.sh
@@ -62,7 +62,7 @@ main() {
         args_knative+=(--knative-eventing "${INPUT_KNATIVE_EVENTING}")
     fi
 
-    if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "${INPUT_REGISTRY,,}" = "true" ]]; then
+    if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "$(echo ${INPUT_REGISTRY} | tr '[:upper:]' '[:lower:]')" = "true" ]]; then
         if [[ ${args:+exist} == "exist" ]] && [[ ${#args[@]} -gt 0 ]]; then
             "$SCRIPT_DIR/registry.sh" "${args[@]}"
         else
@@ -82,7 +82,7 @@ main() {
         "$SCRIPT_DIR/kind.sh"
     fi
 
-    if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "${INPUT_REGISTRY,,}" = "true" ]]; then
+    if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "$(echo ${INPUT_REGISTRY} | tr '[:upper:]' '[:lower:]')" = "true" ]]; then
         if [[ ${args:+exist} == "exist" ]] && [[ ${#args[@]} -gt 0 ]]; then
             "$SCRIPT_DIR/registry.sh" "--document" "true" "${args[@]}"
         else


### PR DESCRIPTION
fixes tests broken by https://github.com/container-tools/kind-action/pull/10

## Motivation

Many tests are failing on MacOS because they test against very old versions of `kind` that don't work properly on MacOS, thus we can benefit from this problem to upgrade the default version of `kind` to a more recent version.

## Modifications

* Upgrade the default version of `kind` to `v0.17.0`
* Upgrade the default version of `kubectl` to `v1.26.1`
* Test against the latest versions of `kind`,  `kubectl` and `knative`
* Ensure that the tests are launched for PRs
* Install the latest version of the tool `yq` to make that we have the same version on both OS and thus the same arguments
* Avoid using the syntax `${INPUT_REGISTRY,,}` for lowercase as it is only supported on bash 4 and MacOS still uses v3
* Install `docker` when needed thanks to a dedicated bash function
* Re-use the `tee` to update the file `/etc/hosts` since the workaround doesn't work properly and adapt it for both OS