### PR TITLE
Allow to provide resource limits in case of Mac OS

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,24 @@ jobs:
           kubectl cluster-info
           kubectl get storageclass standard
 
+  test-with-custom-resource-limits:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+
+      - name: Create kind cluster with custom resource limits
+        uses: ./
+        with:
+          cpu: "3"
+          disk: "5"
+          memory: "11"
+      - name: Test
+        run: |
+          kubectl get node $(kubectl get node -o custom-columns=":metadata.name") -o custom-columns="CPU:.status.capacity.cpu" | grep "3" 1> /dev/null && echo "CPU OK"
+          kubectl get node $(kubectl get node -o custom-columns=":metadata.name") -o custom-columns="DISK:.status.capacity.ephemeral-storage" | grep -E "5\d{6}Ki" 1> /dev/null && echo "Disk OK"
+          kubectl get node $(kubectl get node -o custom-columns=":metadata.name") -o custom-columns="MEMORY:.status.capacity.memory" | grep -E "11\d{6}Ki" 1> /dev/null && echo "Memory OK"
+
   test-with-custom-name:
     strategy:
       matrix:

--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ For more information on inputs, see the [API Documentation](https://developer.gi
 - `knative_serving`: The version of Knative Serving to install on the Kind cluster (not installed by default - example: `v1.0.0`)
 - `knative_kourier`: The version of Knative Net Kourier to install on the Kind cluster (not installed by default - example: `v1.0.0`)
 - `knative_eventing`: The version of Knative Eventing to install on the Kind cluster (not installed by default - example: `v1.0.0`)
+- `cpu`: Number of CPUs to be allocated to the virtual machine (default: 2). For Mac OS only.
+- `memory`: Size of the memory in GiB to be allocated to the virtual machine (default: 12). For Mac OS only.
+- `disk`: Size of the disk in GiB to be allocated to the virtual machine (default: 60). For Mac OS only.
 
 ### Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -27,6 +27,12 @@ inputs:
     description: "The version of Knative Net Kourier to install on the Kind cluster (not installed by default - example: v1.0.0)"
   knative_eventing:
     description: "The version of Knative Eventing to install on the Kind cluster (not installed by default - example: v1.0.0)"
+  cpu:
+    description: "For Mac OS only: Number of CPUs to be allocated to the virtual machine (default: 2)"
+  memory:
+    description: "For Mac OS only: Size of the memory in GiB to be allocated to the virtual machine (default: 12)"
+  disk:
+    description: "For Mac OS only: Size of the disk in GiB to be allocated to the virtual machine (default: 60)"
 runs:
   using: "node16"
   main: "main.js"

--- a/main.sh
+++ b/main.sh
@@ -21,6 +21,7 @@ SCRIPT_DIR=$(dirname -- "$(readlink -f "${BASH_SOURCE[0]}" || realpath "${BASH_S
 main() {
     args_kind=()
     args_knative=()
+    args_registry=()
 
     if [[ -n "${INPUT_VERSION:-}" ]]; then
         args_kind+=(--version "${INPUT_VERSION}")
@@ -62,9 +63,21 @@ main() {
         args_knative+=(--knative-eventing "${INPUT_KNATIVE_EVENTING}")
     fi
 
+    if [[ -n "${INPUT_CPU:-}" ]]; then
+        args_registry+=(--cpu "${INPUT_CPU}")
+    fi
+
+    if [[ -n "${INPUT_DISK:-}" ]]; then
+        args_registry+=(--disk "${INPUT_DISK}")
+    fi
+
+    if [[ -n "${INPUT_MEMORY:-}" ]]; then
+        args_registry+=(--memory "${INPUT_MEMORY}")
+    fi
+
     if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "$(echo ${INPUT_REGISTRY} | tr '[:upper:]' '[:lower:]')" = "true" ]]; then
-        if [[ ${args:+exist} == "exist" ]] && [[ ${#args[@]} -gt 0 ]]; then
-            "$SCRIPT_DIR/registry.sh" "${args[@]}"
+        if [[ ${#args_registry[@]} -gt 0 ]]; then
+            "$SCRIPT_DIR/registry.sh" "${args_registry[@]}"
         else
             "$SCRIPT_DIR/registry.sh"
         fi
@@ -83,8 +96,8 @@ main() {
     fi
 
     if [[ -z "${INPUT_REGISTRY:-}" ]] || [[ "$(echo ${INPUT_REGISTRY} | tr '[:upper:]' '[:lower:]')" = "true" ]]; then
-        if [[ ${args:+exist} == "exist" ]] && [[ ${#args[@]} -gt 0 ]]; then
-            "$SCRIPT_DIR/registry.sh" "--document" "true" "${args[@]}"
+        if [[ ${#args_registry[@]} -gt 0 ]]; then
+            "$SCRIPT_DIR/registry.sh" "--document" "true" "${args_registry[@]}"
         else
             "$SCRIPT_DIR/registry.sh" "--document" "true"
         fi


### PR DESCRIPTION
## Motivation

Colima, used as container runtimes on Mac OS, has [default resource (CPU, memory, disk) limits](https://github.com/abiosoft/colima#customizing-the-vm) that we would like to be able to redefine by configuration.

## Modifications:

* Add new input entries to the GitHub action description, one for each limit
* Modify the main script to collect the value of the new input entries and provide them to the registry script
* Modify the registry script to provide the resource limits to the `start` command of `colima`
* Describe the new input entries in the README
* Add an integration test to ensure that specific resource limits are taken into account on Mac OS
* Change the default value of memory allocated to `colima` to 12 Go instead of 2 Go to better fit with [the hardware resources of a Mac OS runner](https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources)

