### PR TITLE
Add hostFromClusterNetwork in registry document

### DIFF
--- a/registry.sh
+++ b/registry.sh
@@ -224,6 +224,7 @@ metadata:
 data:
   localRegistryHosting.v1: |
     host: "${registry_name}:${registry_port}"
+    hostFromClusterNetwork: "${registry_name}:${registry_port}"
     help: "https://kind.sigs.k8s.io/docs/user/local-registry/"
 EOF
 }


### PR DESCRIPTION
## Motivation

On the case a insecure registry is created, it would also be usefull to document its internal cluster communication configuration.

## Modifications

Add to the `local-registry-hosting` configmap the local registry with the host (hostname and port) of the registry, as seen from networking inside the container pods.