### PR TITLE
fix(tests): Use macos 13 with x86 architecture

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -65,7 +65,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Create kind cluster with custom name
+      - name: Create kind cluster with custom name and registry
         uses: ./
         with:
           version: "${{ matrix.version }}"
@@ -88,7 +88,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
 
-      - name: Create kind cluster with custom name
+      - name: Create kind cluster with custom name and without registry
         uses: ./
         with:
           version: "${{ matrix.version }}"

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -135,10 +135,15 @@ jobs:
             exit 1
           fi
 
+          TEST_REGISTRY="kind-registry:5000"
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            TEST_REGISTRY="127.0.0.1:5000"
+          fi
+
           # Test registry usage inside cluster
           docker pull busybox
-          docker tag busybox kind-registry:5000/localbusybox
-          docker push kind-registry:5000/localbusybox
+          docker tag busybox $TEST_REGISTRY/localbusybox
+          docker push $TEST_REGISTRY/localbusybox
 
           kubectl create job test --image=kind-registry:5000/localbusybox
           i=1
@@ -182,12 +187,17 @@ jobs:
             exit 1
           fi
 
+          TEST_REGISTRY="kind-registry:5000"
+          if [ "$RUNNER_OS" == "macOS" ]; then
+            TEST_REGISTRY="127.0.0.1:5000"
+          fi
+
           # Test registry usage inside cluster
           docker pull busybox
-          docker tag busybox kind-registry:5000/localbusybox
+          docker tag busybox $TEST_REGISTRY/localbusybox
 
           # Test delete API
-          OUTPUT=$(docker push kind-registry:5000/localbusybox | grep -o 'digest.*size')
+          OUTPUT=$(docker push $TEST_REGISTRY/localbusybox | grep -o 'digest.*size')
           TRIM=${OUTPUT//digest: /}
           DIGEST=${TRIM// size/}
           exit $(curl -X DELETE kind-registry:5000/v2/localbusybox/manifests/$DIGEST)

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -21,7 +21,7 @@ jobs:
   test-default:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -36,7 +36,7 @@ jobs:
           kubectl get storageclass standard
 
   test-with-custom-resource-limits:
-    runs-on: macos-latest
+    runs-on: macos-13
     steps:
       - name: Checkout
         uses: actions/checkout@v1
@@ -59,7 +59,7 @@ jobs:
         version:
         - v0.17.0
         - v0.16.0
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -82,7 +82,7 @@ jobs:
         version:
         - v0.17.0
         - v0.16.0
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -113,7 +113,7 @@ jobs:
       matrix:
         version:
         - v0.17.0
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -159,7 +159,7 @@ jobs:
       matrix:
         version:
           - v0.17.0
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -197,7 +197,7 @@ jobs:
       matrix:
         knative_version:
         - v1.9.0
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-13]
     runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout

--- a/registry.sh
+++ b/registry.sh
@@ -179,7 +179,7 @@ install_docker() {
         brew install docker docker-buildx colima
         mkdir -p ~/.docker/cli-plugins
         ln -sfn /usr/local/opt/docker-buildx/bin/docker-buildx ~/.docker/cli-plugins/docker-buildx
-        colima start
+        colima start --cpu "$cpu" --memory "$memory" --disk "$disk"
     fi
 }
 


### PR DESCRIPTION
Ref #21

Ref #19

+ Until github action macos using M3 processors with support to nested virtualization is available use macos-13 instead of macos-latest.
+ custom resources test fix
+ Set registry on 127.0.0.1 outside of kind for macos