### PR TITLE
fix: update kubectl download url

### DIFF
--- a/kind.sh
+++ b/kind.sh
@@ -163,7 +163,7 @@ install_kubectl() {
         # for M1 / ARM Macs
         [ $(uname -m) = arm64 ] && curl -sSLo kubectl "https://dl.k8s.io/release/$kubectl_version/bin/darwin/arm64/kubectl"
     else
-        curl -sSLO "https://storage.googleapis.com/kubernetes-release/release/$kubectl_version/bin/linux/amd64/kubectl"
+        curl -sSLO "https://dl.k8s.io/release/$kubectl_version/bin/linux/amd64/kubectl"
     fi
     chmod +x kubectl
     sudo mv kubectl /usr/local/bin/kubectl


### PR DESCRIPTION
Updates the download URL for `kubectl` when using regular Linux runners. With current versions of `kubectl` the old download link is invalid and causes failed runs.